### PR TITLE
Modify rtd section structure

### DIFF
--- a/docs/tool_interface.rst
+++ b/docs/tool_interface.rst
@@ -35,6 +35,22 @@ energy type
 
 View-component definition
 =========================
+.. _main-window-def:
+
+main window
+-----------
+    The window from which the user can interact with the open_plan tool on their computer
+
+
+.. _widget-def:
+
+widget
+------
+    Smaller window within the tool's ref:`main-window-def`.
+    A *widget* can be moved around by the user within the ref:`main-window-def` and collapsed into another *widget* (then each *widget* is accessible via tabs).
+
+
+
 
 .. contents::
    :local:

--- a/docs/tool_interface.rst
+++ b/docs/tool_interface.rst
@@ -9,15 +9,29 @@ Concepts definition
 
 In order to describe the interface, a few definitions are required at first.
 
-* **view**
+.. _view-def:
+
+view
+----
     Description of a given state of the user interface: what should the user be able to interact with in that *view*, which other *view* can the user visit from the current *view*. The collection of *views* form together the user interface. Note: the view does not describe how the interface looks like to the user, this is described in the *view-rendering*
 
-* **view-component**
+.. _view-component-def:
+
+view-component
+--------------
     A *view-component* is a part of a *view* which can be described independently from the view and could be reused in different *views* (a menu bar for example). A *view-component* is described in terms of its attributes and its actions. For example a menu bar has a nested list of items (each item can itself be a list of item: submenus). Each item, if not itself a list, consists of a label (what the user will see) and an action (what will be done upon clicking/selecting the item.)
 
-* **view-rendering**
+.. _view-rendering-def:
+
+view-rendering
+--------------
     How will the a *view* or *component-view* be rendered on the screen. This belongs to frontend and is where the details about color, size, font, placement on screen matter. For example a menu bar which is a *view-component* can have many different *view-rendering* (horizontal with buttons, expandable vertically only on hover, etc.)
 
+.. _energy-type-def:
+
+energy type
+-----------
+    Energy type linked to the different energy sectors: heat, electricity, gas, biomass, H2O
 
 View-component definition
 =========================

--- a/docs/tool_interface.rst
+++ b/docs/tool_interface.rst
@@ -25,7 +25,7 @@ view-component
 
 view-rendering
 --------------
-    How will the a *view* or *component-view* be rendered on the screen. This belongs to frontend and is where the details about color, size, font, placement on screen matter. For example a menu bar which is a *view-component* can have many different *view-rendering* (horizontal with buttons, expandable vertically only on hover, etc.)
+    Description of how a *view* or *component-view* will be rendered on the screen. This belongs to frontend and is where the details about color, size, font, placement on screen matter. For example a menu bar which is a *view-component* can have many different *view-rendering* (horizontal with buttons, expandable vertically only on hover, etc.)
 
 .. _energy-type-def:
 
@@ -33,8 +33,6 @@ energy type
 -----------
     Energy type linked to the different energy sectors: heat, electricity, gas, biomass, H2O
 
-View-component definition
-=========================
 .. _main-window-def:
 
 main window
@@ -51,6 +49,19 @@ widget
 
 
 
+Views definition
+================
+
+.. contents::
+   :local:
+   :depth: 1
+
+----
+
+.. include:: views/landing.rst
+
+View-components definition
+==========================
 
 .. contents::
    :local:

--- a/docs/views/landing.rst
+++ b/docs/views/landing.rst
@@ -1,0 +1,40 @@
+.. reference for this view-component
+.. you can refer to this component using :ref:`<component_name>-label`
+
+.. _<view_name>-label:
+
+
+Landing
+-------
+
+Attributes
+^^^^^^^^^^
+
+Active view-components
+^^^^^^^^^^^^^^^^^^^^^^
+
+- ref:`menu_bar-label`
+- ref:`flow_chart-label`
+- ref:`welcome-label`
+
+
+Actions
+^^^^^^^
+
+Requirement
+^^^^^^^^^^^
+
+- the very first time the user see this view, the ref:`welcome-label` view-component should be displayed (popup, or integrated to the view)
+
+Link with other views
+^^^^^^^^^^^^^^^^^^^^^
+
+Rendering of the view
+^^^^^^^^^^^^^^^^^^^^^
+There are currently 2 types of rendering proposed:
+
+minimalistic:
+    The user does sees a message
+
+engineer style:
+    Most of the menu and flow charts are displayed in widget windows

--- a/docs/views/landing.rst
+++ b/docs/views/landing.rst
@@ -1,7 +1,7 @@
 .. reference for this view-component
 .. you can refer to this component using :ref:`<component_name>-label`
 
-.. _<view_name>-label:
+.. _landing-label:
 
 
 Landing
@@ -9,6 +9,7 @@ Landing
 
 Attributes
 ^^^^^^^^^^
+There are no attributes specific to the landing view.
 
 Active view-components
 ^^^^^^^^^^^^^^^^^^^^^^
@@ -20,21 +21,22 @@ Active view-components
 
 Actions
 ^^^^^^^
+There are no actions specific to the landing view, the possible actions are already defined in the various view-components
 
 Requirement
 ^^^^^^^^^^^
-
-- the very first time the user see this view, the ref:`welcome-label` view-component should be displayed (popup, or integrated to the view)
+- the very first time the user sees this view, the ref:`welcome-label` view-component should be displayed (popup, or integrated to the view)
 
 Link with other views
 ^^^^^^^^^^^^^^^^^^^^^
+TBD
 
 Rendering of the view
 ^^^^^^^^^^^^^^^^^^^^^
 There are currently 2 types of rendering proposed:
 
 minimalistic:
-    The user does sees a message
+    The user is only prompted to "build your own energy cell"
 
 engineer style:
     Most of the menu and flow charts are displayed in widget windows

--- a/docs/views/view_template.rst
+++ b/docs/views/view_template.rst
@@ -1,0 +1,26 @@
+.. reference for this view-component
+.. you can refer to this component using :ref:`<component_name>-label`
+
+.. _<view_name>-label:
+
+
+View-title
+----------
+
+Attributes
+^^^^^^^^^^
+
+Active view-components
+^^^^^^^^^^^^^^^^^^^^^^
+
+Actions
+^^^^^^^
+
+Requirement
+^^^^^^^^^^^
+
+Link with other views
+^^^^^^^^^^^^^^^^^^^^^
+
+Rendering of the view
+^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
**Changes proposed in this pull request**:
- Add `views` folder and a `Views definition` section in `tool_interface.rst`
- Change `Concepts definition` entries into sections by underlining them with `-`


<sub>*For more information on how to contribute check the [CONTRIBUTING.md](https://github.com/rl
-institut/open_plan/blob/dev/CONTRIBUTING.md).*<sub>
