### PR TITLE
Fix/adapt viewcomponents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ Here is a template for new release sections
 - Description of energy_system_component view-component (#32)
 
 ### Changed
-- another thing
+- Modified the view-components according to the changed template (#35)
 
 ### Removed
 - yet another thing

--- a/docs/tool_interface.rst
+++ b/docs/tool_interface.rst
@@ -88,13 +88,13 @@ View-components definition
 
 ----
 
-.. _progression_bar-label:
+.. _progression-bar-label:
 
 .. include:: view_components/progression_bar.rst
 
 ----
 
-.. _menu_bar-label:
+.. _menu-bar-label:
 
 .. include:: view_components/menu_bar.rst
 

--- a/docs/view_components/menu_bar.rst
+++ b/docs/view_components/menu_bar.rst
@@ -1,3 +1,5 @@
+.. _menu-bar-label:
+
 Menu Bar
 --------
 
@@ -6,28 +8,27 @@ Menu bar is a set of options linked to actions, or submenus.
 Attributes
 ^^^^^^^^^^
 
-* The following are the menus available in the menu bar:
+**The following are the menus available in the menu bar:**
     #. File
     #. Scenarios
     #. Preferences
     #. Help
-* *File* has the following submenus or options:
+***File* has the following submenus or options:**
     I. Load project
     II. New project
     III. Save project
     IV. Save project as
     V. Export project
     VI. Exit open_plan
-* *Scenarios* has the following submenus:
+***Scenarios* has the following submenus:**
     I. New scenario
     II. Load scenario
     III. ---- (separating horizontal line)
     IV. List of scenarios in the system
-
-* *Preferences* has the following submenus:
+***Preferences* has the following submenus:**
     I. Language
     II. Display
-* *Help* has the following submenus:
+***Help* has the following submenus:**
     I. Read documentation
     II. Examples and use cases
     III. Contact developers
@@ -38,31 +39,37 @@ Attributes
 Actions
 ^^^^^^^
 
-* Clicking on any of the menus' option results in a drop-down list of sub-menu's options
-* Clicking on *File* would show a drop-down list with the following submenus or options:
+1. Clicking on any of the menus' option results in a drop-down list of sub-menu's options
+2. Clicking on *File* would show a drop-down list with the following submenus or options:
     I. Load project
     II. New project
     III. Save project
     IV. Save project as
     V. Export project
     VI. Exit open_plan
-* clicking on *Preferences* would show a drop-down list with the following submenus or options:
+3. clicking on *Preferences* would show a drop-down list with the following submenus or options:
     I. Language
     II. Display
-* User can change the scenario by clicking on the specific scenario under the *Scenarios* menu or load their own scenario as well, or create a new scenario
+4. User can change the scenario by clicking on the specific scenario under the *Scenarios* menu or load their own scenario as well, or create a new scenario
 
 Requirement
 ^^^^^^^^^^^
 
-* The menu/submenu's options that are not applicable are greyed out or inactive and thus, nothing happens when clicked upon
+1. The menu/submenu's options that are not applicable are greyed out or inactive and thus, nothing happens when clicked upon
+
+Link with views
+^^^^^^^^^^^^^^^
+
+.. TBD
 
 Link with other view-components
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-* :ref:`welcome-label`:
+**:ref:`welcome-label`**
     The welcome view-component can be re-enabled if it was disabled by the user from appearing everytime the tool is launched.
 
-* :ref:`progression_bar-label`
+**:ref:`progression_bar-label`**
+.. TDB
 
 Rendering of the view-component
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/view_components/menu_bar.rst
+++ b/docs/view_components/menu_bar.rst
@@ -65,10 +65,10 @@ Link with views
 Link with other view-components
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-**:ref:`welcome-label`**
+:ref:`welcome-label`
     The welcome view-component can be re-enabled if it was disabled by the user from appearing everytime the tool is launched.
 
-**:ref:`progression_bar-label`**
+:ref:`progression_bar-label`
 .. TDB
 
 Rendering of the view-component

--- a/docs/view_components/progression_bar.rst
+++ b/docs/view_components/progression_bar.rst
@@ -15,7 +15,7 @@ A Progression bar view-component has a number of advantages:
 Attributes
 ^^^^^^^^^^
 
-**Several simulation steps constitute the progression bar**
+**List of simulation steps below constitute the progression bar**
     #. Project Setup
     #. Inputs
     #. System Inputs
@@ -23,8 +23,9 @@ Attributes
     #. Constraints
     #. Simulations
     #. Results
-**Each step has an associated index, with the progression being bar considered as an array**
-** The current state of the view depends on the index of the current step**
+
+    Properties:
+        *Each step has an associated index, corresponding to its position in the list of steps
 
 Actions
 ^^^^^^^

--- a/docs/view_components/progression_bar.rst
+++ b/docs/view_components/progression_bar.rst
@@ -1,3 +1,5 @@
+.. _progression-bar-label:
+
 Progression Bar
 ---------------
 
@@ -13,7 +15,7 @@ A Progression bar view-component has a number of advantages:
 Attributes
 ^^^^^^^^^^
 
-* The steps that constitute the progression bar are as follows:
+**Several simulation steps constitute the progression bar**
     #. Project Setup
     #. Inputs
     #. System Inputs
@@ -21,26 +23,32 @@ Attributes
     #. Constraints
     #. Simulations
     #. Results
-* Each step has an associated index, with the progression being bar considered as an array
-* The current state of the view depends on the index of the current step
+**Each step has an associated index, with the progression being bar considered as an array**
+** The current state of the view depends on the index of the current step**
 
 Actions
 ^^^^^^^
 
-* To make the next step of the Progression bar clickable, the user has to fulfill the requirements of the current step. Each step has various mandatory and optional fields.
-* Clicking on the steps of the flowchart that have been fulfilled already allows the user to make modifications. 
-* Clicking on the steps that are not clickable make a small text bubble appear saying the previous step needs to be fulfilled first.
+1. To make the next step of the Progression bar clickable, the user has to fulfill the requirements of the current step. Each step has various mandatory and optional fields.
+2. Clicking on the steps of the Progression bar that have been fulfilled already allows the user to make modifications.
+3. Clicking on the steps that are not clickable make a small text bubble appear saying the previous step needs to be fulfilled first.
 
 Requirement
 ^^^^^^^^^^^
 
-* The user has to progress through the progression bar in order to successfully carry out the modeling and simulation
-* Each step has to be completed one at a time. Once a step has met its minimum requirements, the button of the next step becomes clickable. Therefore, the user can come back to the steps they have already seen but they cannot click on a random step.
+1. The user has to progress through the progression bar in order to successfully carry out the modeling and simulation
+2. Each step has to be completed one at a time. Once a step has met its minimum requirements, the button of the next step becomes clickable. Therefore, the user can come back to the steps they have already seen but they cannot click on a random step.
+
+Link with views
+^^^^^^^^^^^^^^^
+
+.. TBD
 
 Link with other view-components
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-* :ref:`menu_bar-label`
+**:ref:`menu_bar-label`**
+.. TBD
 
 Rendering of the view-component
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/view_components/progression_bar.rst
+++ b/docs/view_components/progression_bar.rst
@@ -47,7 +47,7 @@ Link with views
 Link with other view-components
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-**:ref:`menu_bar-label`**
+:ref:`menu_bar-label`
 .. TBD
 
 Rendering of the view-component


### PR DESCRIPTION
Fix #34 

**Changes proposed in this pull request**:
- View-component descriptions will be adapted to follow the guidelines laid down in the view-component template file

The following steps were realized, as well (if applies):
- [x] Apply black (`black . --exclude docs/`)
- [x] Update the CHANGELOG.md

The following optional steps were realized:
- [x] Use in-line comments to explain your code
- [x] Write docstrings to your code
- [x] For new functionalities: explain in readthedocs
- [ ] Write test(s) for your new patch of code


<sub>*For more information on how to contribute check the [CONTRIBUTING.md](https://github.com/rl
-institut/open_plan/blob/dev/CONTRIBUTING.md).*<sub>
