### PR TITLE
Put the RDT in full width of the screen 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Here is a template for new release sections
 ### Changed
 - Modified the view-components according to the changed template (#35)
 - Unify description and cross-reference of view-components (#51)
+- Adjust ReadTheDocs template to enable max-width when reeading the documentation (#61)
 
 ### Removed
 - yet another thing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@ Here is a template for new release sections
 ### Changed
 - Modified the view-components according to the changed template (#35)
 - Unify description and cross-reference of view-components (#51)
-- Adjust ReadTheDocs template to enable max-width when reeading the documentation (#61)
+- Adjust ReadTheDocs' template to enable max-width when reading the documentation (#61)
 
 ### Removed
 - yet another thing

--- a/docs/_static/style.css
+++ b/docs/_static/style.css
@@ -1,0 +1,3 @@
+.wy-nav-content {
+    max-width: none;
+}

--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -1,0 +1,4 @@
+{% extends "!layout.html" %}
+{% block extrahead %}
+    <link href="{{ pathto("_static/style.css", True) }}" rel="stylesheet" type="text/css">
+{% endblock %}


### PR DESCRIPTION
Fix #60 

**Changes proposed in this pull request**:
- Create style.css in open_plan/doc/_static
- Add source/_templates/layout.html

The following steps were realized, as well (if applies):
- [x] Update the CHANGELOG.md

<sub>*For more information on how to contribute check the [CONTRIBUTING.md](https://github.com/rl
-institut/open_plan/blob/dev/CONTRIBUTING.md).*<sub>
