### PR TITLE
Add view-component to see specific parts of the docs from the tool UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Here is a template for new release sections
 - Add input parameter field view-component to docs (#49)
 - Create landing page for GUI draft (#47)
 - Create `Attribute` definition (#52)
+- Add description for the view-component to access specific sections of the docs (#63)
 
 
 ### Changed

--- a/docs/tool_interface.rst
+++ b/docs/tool_interface.rst
@@ -178,6 +178,10 @@ View-components definition
 
 .. include:: view_components/export_project.rst
 
+.. _view_specific_docs-label:
+
+.. include:: view_components/view_specific_documentation.rst
+
 
 Abstract-components Definition
 ==============================

--- a/docs/tool_interface.rst
+++ b/docs/tool_interface.rst
@@ -178,7 +178,7 @@ View-components definition
 
 .. include:: view_components/export_project.rst
 
-.. _view_specific_docs-label:
+.. _view_specific_documentation-label:
 
 .. include:: view_components/view_specific_documentation.rst
 
@@ -196,4 +196,3 @@ Abstract-components Definition
 .. _scenario-label:
 
 .. include:: abstract_components/scenario.rst
-

--- a/docs/view_components/view_specific_documentation.rst
+++ b/docs/view_components/view_specific_documentation.rst
@@ -1,7 +1,7 @@
 View Specific Documentation
 ---------------------------
 
-This view-component lets the user access the specific sections of the documentation directly from within the tool UI.
+This view-component lets the user access the specific sections of the documentation directly from within the tool UI. It serves as a tooltip for input parameters.
 
 Attributes
 ^^^^^^^^^^
@@ -22,7 +22,7 @@ Attributes
     Content of the documentation such as text, images, hyperlinks, etc., to be rendered
 
 **button** :guilabel:`&Download PDF`
-    A button
+    Clicking this triggers the download of a pdf of the documentation
 
     Actions index: 3
 
@@ -54,6 +54,7 @@ Link with other view-components
     Generic view-component that describes the fields where user inputs are necessary
 
 :ref:`load_input_parameter-label`
+    Description of the link
 
 :ref:`scenario_parameters-label`
     View-component where the user inputs the scenario-specific parameters

--- a/docs/view_components/view_specific_documentation.rst
+++ b/docs/view_components/view_specific_documentation.rst
@@ -1,80 +1,67 @@
 View Specific Documentation
 ---------------------------
 
+This view-component lets the user access the specific sections of the documentation directly from within the tool UI.
+
 Attributes
 ^^^^^^^^^^
-.. Please refer to the definition of what an attribute is in the tool_interface.rst file
-.. The properties should be filled in only if applicable.
 
-**Attribute A**
-    Description
+**Scroll Bar**
+    This bar lets the user navigate the documentation content
 
-    Properties:
-        * Property 1
-        * ...
-        * Property n
-
-    Actions index:
+    Actions index: 1
 
     Requirements index:
 
-.. [One liner] corresponding indexes from the Actions and Requirements paragraph below
+**Side navigation pane**
+    This navigation pane is akin to a table of contents and lets the user jump to other sections of the documentation quickly
 
-**Attribute B**
-    Description
+    Actions index: 2
 
-    Properties:
-        * Property 1
-        * ...
-        * Property n
+**Content**
+    Content of the documentation such as text, images, hyperlinks, etc., to be rendered
 
-    Actions index:
+**Download PDF**
+    A button
+
+    Actions index: 3
 
     Requirements index:
-
-.. [One liner] corresponding indexes from the Actions and Requirements paragraph below
 
 Actions
 ^^^^^^^
-..
-    an action is something one can perform directly from the view-component
-    (i.e. "clicking on this attribute should update this other attribute")
 
-1. Action 1
-2. Action 2
+1. User can scroll through the documentation using the scroll bar
+2. User can jump to other sections of the documentation using the links in the navigation pane
+3. User can click on the Download PDF button to obtain a local copy of the documentation
 
 Requirements
 ^^^^^^^^^^^^
-..
-    a requirement is a binding rule which cannot be described directly by an action
-    or which describes redundant actions
-    (i.e. "it should not be possible to click on this attribute while the value of this other
-    attribute is not defined", or "after changing the value of an already defined attribute,
-    one should see a difference in the rendering of the attribute"
 
-1. Requirement 1
-2. Requirement 2
+1. User must be able to open this view-component through clicking on links next to various elements in other views/view-components
 
 Link with views
 ^^^^^^^^^^^^^^^
 .. use :ref:`<view>-label` to cross link to the view's description directly
 
-:ref:`<view1>-label`
-    Description of the link
-
-:ref:`<view2>-label`
-    Description of the link
-
 Link with other view-components
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. use :ref:`<view_component>-label` to cross link to the view-component's description directly
 
-:ref:`<view_component1>-label`
-    Description of the link
+:ref:`welcome-label`
+    First view-component on the landing view of the tool, seen by the user. Contains link to documentation
 
-:ref:`<view_component2>-label`
-    Description of the link
+:ref:`input_parameter_field-label`
+    Generic view-component that describes the fields where user inputs are necessary
+
+:ref:`load_input_parameter-label`
+
+:ref:`scenario_parameters-label`
+    View-component where the user inputs the scenario-specific parameters
+
+:ref:`project_parameters-label`
+    View-component where the user inputs the project parameters
 
 Rendering of the view-component
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. TBD
+
+This view-component could either be a pop-up on top of the view the user is currently in, or as a new tab on a browser window opening relevant sections of readthedocs directly

--- a/docs/view_components/view_specific_documentation.rst
+++ b/docs/view_components/view_specific_documentation.rst
@@ -1,0 +1,80 @@
+View Specific Documentation
+---------------------------
+
+Attributes
+^^^^^^^^^^
+.. Please refer to the definition of what an attribute is in the tool_interface.rst file
+.. The properties should be filled in only if applicable.
+
+**Attribute A**
+    Description
+
+    Properties:
+        * Property 1
+        * ...
+        * Property n
+
+    Actions index:
+
+    Requirements index:
+
+.. [One liner] corresponding indexes from the Actions and Requirements paragraph below
+
+**Attribute B**
+    Description
+
+    Properties:
+        * Property 1
+        * ...
+        * Property n
+
+    Actions index:
+
+    Requirements index:
+
+.. [One liner] corresponding indexes from the Actions and Requirements paragraph below
+
+Actions
+^^^^^^^
+..
+    an action is something one can perform directly from the view-component
+    (i.e. "clicking on this attribute should update this other attribute")
+
+1. Action 1
+2. Action 2
+
+Requirements
+^^^^^^^^^^^^
+..
+    a requirement is a binding rule which cannot be described directly by an action
+    or which describes redundant actions
+    (i.e. "it should not be possible to click on this attribute while the value of this other
+    attribute is not defined", or "after changing the value of an already defined attribute,
+    one should see a difference in the rendering of the attribute"
+
+1. Requirement 1
+2. Requirement 2
+
+Link with views
+^^^^^^^^^^^^^^^
+.. use :ref:`<view>-label` to cross link to the view's description directly
+
+:ref:`<view1>-label`
+    Description of the link
+
+:ref:`<view2>-label`
+    Description of the link
+
+Link with other view-components
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. use :ref:`<view_component>-label` to cross link to the view-component's description directly
+
+:ref:`<view_component1>-label`
+    Description of the link
+
+:ref:`<view_component2>-label`
+    Description of the link
+
+Rendering of the view-component
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. TBD

--- a/docs/view_components/view_specific_documentation.rst
+++ b/docs/view_components/view_specific_documentation.rst
@@ -21,7 +21,7 @@ Attributes
 **Content**
     Content of the documentation such as text, images, hyperlinks, etc., to be rendered
 
-**Download PDF**
+**button** :guilabel:`&Download PDF`
     A button
 
     Actions index: 3


### PR DESCRIPTION
Fix #50 

**Changes proposed in this pull request**:
- Add description for the view-component to access specific sections of the docs from the tool UI

The following steps were realized, as well (if applies):
- [x] Apply black (`black . --exclude docs/`)
- [x] Update the CHANGELOG.md

The following optional steps were realized:
- [ ] Use in-line comments to explain your code
- [ ] Write docstrings to your code
- [x] For new functionalities: explain in readthedocs
- [ ] Write test(s) for your new patch of code


<sub>*For more information on how to contribute check the [CONTRIBUTING.md](https://github.com/rl
-institut/open_plan/blob/dev/CONTRIBUTING.md).*<sub>
