### PR TITLE
Update energy_system_network.rst

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ Here is a template for new release sections
 - Description of load_scenario view component (#29)
 - Template for views (#33)
 - Description of energy_system_sector_selector view component (#38)
-- Description of energy_system_network view-component (#11, #40)
+- Description of energy_system_network view-component (#11, #40, #81)
 - Description of energy_system_component view-component (#32) 
 - Template for view-component (#24)
 - Description of load_scenario view-component (#29)

--- a/docs/view_components/energy_system_network.rst
+++ b/docs/view_components/energy_system_network.rst
@@ -11,9 +11,9 @@ Attributes
     A list of energy busses
     
     Properties:
-        - id: `es_bus_list`
-        - each bus has a unique id
-        - each bus has an associated :ref:`energy-type-def`
+        * id: `es_bus_list`
+        * each bus has a unique id
+        * each bus has an associated :ref:`energy-type-def`
 
     Actions index: 1, 2, 4
 
@@ -24,7 +24,7 @@ Attributes
     Linked to the action of adding a bus to the `es_bus_list`
 
     Properties:
-        - id `add_es_bus`
+        * id `add_es_bus`
 
     Actions index: 1, 5, 6
 
@@ -45,14 +45,8 @@ Attributes
     A list of *energy system components*
     
     Properties:
-        - id: `es_component_list`
-        - each *energy system component* has a unique id
-        - each *energy system component* has a list of associated :ref:`energy-type-def`
-        - each *energy system component* can have in and/or out connection to one of the energy busses or one of the other energy system components
-        - each *energy system component* has a type (sink, source, transformer, storage)
-        .. these properties are all described in energy_system_component.rst already, isn't that redundant? Should we delete them here?
-
-
+        * id: `es_component_list`
+  
     Actions index: 1, 2, 4
 
 

--- a/docs/view_components/energy_system_network.rst
+++ b/docs/view_components/energy_system_network.rst
@@ -1,13 +1,15 @@
 Energy System network
 ---------------------
 
-This view-component will help the user to define their energy system.
+This view-component will help the user to define their energy system model
 
 
 Attributes
 ^^^^^^^^^^
 
 **list of energy busses**
+    A list of energy busses
+    
     Properties:
         - id: `es_bus_list`
         - each bus has a unique id
@@ -33,53 +35,53 @@ Attributes
     Linked to the action of removing a bus from the `es_bus_list`
 
     Properties:
-        - id `remove_es_bus`
+        * id `remove_es_bus`
 
     Actions index: 2, 3
 
     Requirements index:
 
 **list of energy system component**
-    properties:
+    A list of *energy system components*
+    
+    Properties:
         - id: `es_component_list`
-        - each energy system component has a unique id
-        - each energy system component has a list of associated :ref:`energy-type-def`
-        - each energy system component can have in and/or out connection to one of the energy busses or one of the other energy system components
-        - each energy system component has a type (sink, source, transformer, storage)
+        - each *energy system component* has a unique id
+        - each *energy system component* has a list of associated :ref:`energy-type-def`
+        - each *energy system component* can have in and/or out connection to one of the energy busses or one of the other energy system components
+        - each *energy system component* has a type (sink, source, transformer, storage)
+        .. these properties are all described in energy_system_component.rst already, isn't that redundant? Should we delete them here?
 
 
     Actions index: 1, 2, 4
 
 
 **button** :guilabel:`&Add component`
-
     Linked to the action of adding an energy system component to the `es_component_list`
 
     Properties:
-        - id `add_es_component`
+        * id `add_es_component`
 
     Actions index: 1, 5, 6
 
     Requirements index:
 
 **button** :guilabel:`&Remove component`
-
     Linked to the action of removing an energy system component from the `es_component_list`
 
     Properties:
-        - id `remove_es_component`
+        * id `remove_es_component`
 
     Actions index: 2, 3
 
     Requirements index:
 
 **Draw area**
-
     Area where the user could drag and drop components and connect them, or simply see a rendering
     of the energy system graph withtout being able to interact with it
 
     Properties:
-    - id `network_schema`
+        * id `network_schema`
 
     Actions index: 4.
 
@@ -87,30 +89,34 @@ Attributes
 
 
 **Text area**
-    displays potential error messages arising from wrong configuration of energy system network or single energy system component
+    Displays potential error messages arising from wrong configuration of *energy system network* or single *energy system component*
 
     Properties:
-    - id `error_log`
-
-
+        * id `error_log`
 
 
 Actions
 ^^^^^^^
 
-1. Clicking on the `add es_bus`/`add es_component` button adds a bus or an energy system component to the `es_bus_list`/`es_component_list`, respectively.
-2. Clicking on the `remove_es_bus`/`remove_es_component` button removes the currently selected bus or energy system component from the `es_bus_list`/`es_component_list`, respectively.
-3. Clicking on the `remove_es_bus`/`remove_es_component` button when no bus or energy system component is currently selected sends a log message to the `error_log`.
+1. Clicking on the `add es_bus`/`add es_component` button adds a *Bus* or an *energy system component* to the `es_bus_list`/`es_component_list`, respectively.
+2. Clicking on the `remove_es_bus`/`remove_es_component` button removes the currently selected *Bus* or *energy system component* from the `es_bus_list`/`es_component_list`, respectively.
+3. Clicking on the `remove_es_bus`/`remove_es_component` button when no *Bus* or *energy system component* is currently selected sends a log message to the `error_log`.
 4. Selecting a bus or an energy system component in `es_bus_list`, `es_component_list` or in `network_schema` allows the user to visualise and/or edit its properties in another view-component.
-5. When a the user add a bus or an energy system component by clicking on the `add_es_bus`/`add_es_component`, they can visualise and/or edit its properties in another view-component.
-6. When a the user add a bus or an energy system component by clicking on the `add_es_bus`/`add_es_component`, they can to see it in the `network_schema`.
+5. When a the user add a *Bus* or *energy system component* by clicking on the `add_es_bus`/`add_es_component`, they can visualise and/or edit its properties in another view-component.
+6. When a the user add a *Bus* or *energy system component* by clicking on the `add_es_bus`/`add_es_component`, they can to see it in the `network_schema`.
 
 Requirements
 ^^^^^^^^^^^^
 
-1. each energy bus needs to be connected to at least one energy system component of type source
+1. each energy *Bus* needs to be connected to at least one energy system component of type source
+.. this requirment is not true, see the pull request #79
+
 2. if the user does not provide an energy system component of type sink for an energy bus, the latter is created automatically
-3. notifications informing the user about potential problems with their energy system should be displayed in the `error_log` text area. Problems could be such as a failure to meet any of the other requirements, an undefined property value of an energy system component, or a bus connected to no energy system component
+.. i guess this should be done to dump excess energy flows. The problem is that you can't generalize here. Also, you would probably need a source as slack, in case the sum of energy flows do not fulfill the demand. How about, we phrase it as such: 
+.. 2. If not defined by the user, an additional Sink component to dump excess energy flow is defined and connected automatically to one *Bus* in the *energy system network*
+
+3. If not defined by the user, an additional Source component to provide slack energy flow is defined and connected automatically to one *Bus* in the *energy system network* 
+4. notifications informing the user about potential problems with their energy system model should be displayed in the `error_log` text area. Problems could be such as a failure to meet any of the other requirements, an undefined property value of an *energy system component*, or a *Bus* without connection to another *energy system component*
 
 
 Link with other view-components
@@ -120,4 +126,4 @@ Link with other view-components
 Rendering of the view-component
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-The buttons need to be visible at all time, as the selection of energy system components or busses can be done either from the lists `es_bus_list`, `es_component_list` or from `network_schema`, they do not necessarily need to be seen at the same time (they could be side by side or accessible via tabs)
+The buttons need to be visible at all time, as the selection of *energy system components* or *Busses* can be done either from the lists `es_bus_list`, `es_component_list` or from `network_schema`, they do not necessarily need to be seen at the same time (they could be side by side or accessible via tabs)

--- a/docs/view_components/energy_system_network.rst
+++ b/docs/view_components/energy_system_network.rst
@@ -102,15 +102,9 @@ Actions
 Requirements
 ^^^^^^^^^^^^
 
-1. each energy *Bus* needs to be connected to at least one energy system component of type source
-.. this requirment is not true, see the pull request #79
-
-2. if the user does not provide an energy system component of type sink for an energy bus, the latter is created automatically
-.. i guess this should be done to dump excess energy flows. The problem is that you can't generalize here. Also, you would probably need a source as slack, in case the sum of energy flows do not fulfill the demand. How about, we phrase it as such: 
-.. 2. If not defined by the user, an additional Sink component to dump excess energy flow is defined and connected automatically to one *Bus* in the *energy system network*
-
-3. If not defined by the user, an additional Source component to provide slack energy flow is defined and connected automatically to one *Bus* in the *energy system network* 
-4. notifications informing the user about potential problems with their energy system model should be displayed in the `error_log` text area. Problems could be such as a failure to meet any of the other requirements, an undefined property value of an *energy system component*, or a *Bus* without connection to another *energy system component*
+1. If not defined by the user, an additional Sink component to dump excess energy flow is defined and connected automatically to one *Bus* in the *energy system network*
+2. If not defined by the user, an additional Source component to provide slack energy flow is defined and connected automatically to one *Bus* in the *energy system network*
+3. notifications informing the user about potential problems with their energy system model should be displayed in the `error_log` text area. Problems could be such as a failure to meet any of the other requirements, an undefined property value of an *energy system component*, or a *Bus* without connection to another *energy system component*
 
 
 Link with other view-components


### PR DESCRIPTION
I updated some formatting and content of the energy_system_network.rst file. 

Generally, I see a bit of a problem in speaking of *Bus* and *energy system components* as two separate objects, as from my understanding a *Bus* is part of *energy system component*. How do we deal with that? Should we separate them into two view-components or simply phrase it differently? 

In the code there are some comments that require further discussion. 