### PR TITLE
Create static files for website

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ Here is a template for new release sections
 - Website content (#83)
 - Add input and output tables in parameters category (#59)
 - Add definition of a project and a scenario (#102)
-
+- Module `create_static_website.py`, described in `website/README.md` (#109)
 
 ### Changed
 - Modified the view-components according to the changed template (#35)

--- a/create_static_website.py
+++ b/create_static_website.py
@@ -1,0 +1,64 @@
+import os
+import requests
+import time
+import uvicorn
+import threading
+import contextlib
+
+from website.webapp import app
+
+
+def convert_webapp_to_html_files():
+    url_list = ["", "imprint", "publications", "privacy"]
+
+    url_base = "http://127.0.0.1:5001"
+
+    for url in url_list:
+
+        r = requests.get(url_base + "/" + url)
+
+        if url == "":
+            fname = "index"
+        else:
+            fname = url
+
+        with open(f"{fname}.html", "w") as fp:
+            html_text = r.text
+
+            # replace href to other endpoints with html files
+            for href in url_list[1:]:
+                html_text = html_text.replace(f'href="{url_base}/{href}"', f'href="{href}.html"')
+
+            # fix href to css, js, and images files in the static folder
+            html_text = html_text.replace("../static", "website/static")
+            html_text = html_text.replace(url_base + "/static", "website/static")
+
+            fp.write(html_text)
+
+
+class Server(uvicorn.Server):
+    def install_signal_handlers(self):
+        # overload this method which otherwise only work in main thread
+        pass
+
+    @contextlib.contextmanager
+    def run_in_thread(self):
+        thread = threading.Thread(target=self.run)
+        thread.start()
+        try:
+            while not self.started:
+                time.sleep(1e-3)
+            yield
+        finally:
+            self.should_exit = True
+            thread.join()
+
+
+config = uvicorn.Config(
+    app, host="127.0.0.1", port=5001, log_level="info", loop="asyncio"
+)
+server = Server(config=config)
+
+
+with server.run_in_thread():
+    convert_webapp_to_html_files()

--- a/website/README.md
+++ b/website/README.md
@@ -24,3 +24,13 @@ Any `.scss` file in `/static/css` folder will be converted to a `.css` file auto
     <link rel="stylesheet" href="{{ url_for('static', path='/css/<name of your scss file>.css') }}">
     
 Note the file name is the same, only the extension changes from `.scss` to `.css`
+
+## Generate files for a static website
+
+Execute the script
+
+    python create_static_website.py
+
+from the repository's root, the file will be generated automatically in the repository's root.
+
+The index page is `index.html`

--- a/website/templates/footer.html
+++ b/website/templates/footer.html
@@ -6,8 +6,8 @@
     <div class="footer__content">
       <div class="footer__links">
         <a href="https://github.com/rl-institut/open_plan" target="_blank" rel="noopener noreferrer">GitHub</a>
-        <a href="imprint">Imprint</a>
-        <a href="privacy">Privacy</a>
+        <a href="{{ url_for('imprint') }}">Imprint</a>
+        <a href="{{ url_for('privacy') }}">Privacy</a>
       </div>
       <div class="footer__licence">
         <p>Content of this webpage - except for the partner logos - is licensed under CC-BY-4.0 conditions.</p>

--- a/website/templates/index.html
+++ b/website/templates/index.html
@@ -107,7 +107,7 @@
         <p>If you want to collaborate or are interested in the project, you can find more information on:</p>
       </div>
       <div class="dev__links">
-        <a href="publications" class="btn btn--full">Publications</a>
+        <a href="{{ url_for('publications') }}" class="btn btn--full">Publications</a>
         <a href="https://github.com/rl-institut/open_plan" class="btn btn--hollow">GitHub</a>
         <a href="https://open-plan.readthedocs.io/en/latest/?badge=latest" class="btn btn--hollow">Read the Docs</a>
       </div>

--- a/website/webapp.py
+++ b/website/webapp.py
@@ -55,12 +55,12 @@ def imprint(request: Request) -> Response:
 
 
 @app.get("/privacy")
-def imprint(request: Request) -> Response:
+def privacy(request: Request) -> Response:
     compile_scss_files()
     return templates.TemplateResponse("privacy.html", {"request": request})
 
 
 @app.get("/publications")
-def imprint(request: Request) -> Response:
+def publications(request: Request) -> Response:
     compile_scss_files()
     return templates.TemplateResponse("publications.html", {"request": request})


### PR DESCRIPTION
**Changes proposed in this pull request**:
- Add a way to print all the open_plan website to html files so we can display it as static webpage

The following steps were realized, as well (if applies):
- [x] Apply black (`black . --exclude docs/`)
- [x] Update the CHANGELOG.md

<sub>*For more information on how to contribute check the [CONTRIBUTING.md](https://github.com/rl
-institut/open_plan/blob/dev/CONTRIBUTING.md).*<sub>
