### PR TITLE
Fix header title overlap and center cell image between texts

### DIFF
--- a/website/static/css/style.scss
+++ b/website/static/css/style.scss
@@ -371,9 +371,14 @@ html {
 		@media screen and (min-width: 640px) {
 			.text--left {
 				padding-right: 1.5rem;
+				flex: 1 1 0px;
 		   	}
 		   	.text--right {
-			   	padding-left: 2rem;
+				padding-left: 2rem;
+				flex: 1 1 0px;
+			}
+			.img {
+				flex: 1 1 0px;
 			}
 		}
 		@media screen and (min-width: 1280px) {

--- a/website/static/css/style.scss
+++ b/website/static/css/style.scss
@@ -1,6 +1,6 @@
 /* ----------------- Mixins ---------------- */
 @mixin section-wrap($desktop-width, $section-padding-top-btm) {
-	padding: 2rem 1rem 0;
+	padding: 3rem 1rem 0;
 	display: flex;
 	flex-direction: column;
 
@@ -250,7 +250,7 @@ html {
 	background-size: contain;
 	height: auto;
 	padding-bottom: 3rem;
-	padding-top: 2rem;
+	padding-top: 3rem;
 
 	@media screen and (min-width: 640px) {
 		background-image: url(../assets/open_plan_hero_hexagon.svg);

--- a/website/static/css/style.scss
+++ b/website/static/css/style.scss
@@ -1,11 +1,11 @@
 /* ----------------- Mixins ---------------- */
-@mixin section-wrap($desktop-width) {
+@mixin section-wrap($desktop-width, $section-padding-top-btm) {
 	padding: 2rem 1rem 0;
 	display: flex;
 	flex-direction: column;
 
 	@media screen and (min-width: 640px) {
-		padding: 4rem 2rem 0;
+		padding: $section-padding-top-btm 2rem 0;
 	}
 	@media screen and (min-width: 1280px) {
 		max-width: $desktop-width;
@@ -271,7 +271,7 @@ html {
 	}
 	
 	&__wrap {
-		@include section-wrap(1280px);
+		@include section-wrap(1280px, 7rem);
 	}
 
 	&__heading {
@@ -334,7 +334,7 @@ html {
 	width: 100%;
 
 	&__wrap {
-		@include section-wrap(1280px);
+		@include section-wrap(1280px, 4rem);
 		@media screen and (min-width: 640px) {
 			padding-top: 8rem;
 		}
@@ -474,7 +474,7 @@ html {
 		padding-top: 6rem;
 	}
 	&__wrap {
-		@include section-wrap(1280px);
+		@include section-wrap(1280px, 4rem);
 		box-shadow: 0px 8px 32px 16px rgba(31, 86, 125, 0.08);
 		padding-top: 2.5rem;
 		padding-bottom: 2rem;
@@ -560,7 +560,7 @@ html {
 	width: 100%;
 
 	&__wrap {
-		@include section-wrap(1280px);
+		@include section-wrap(1280px, 4rem);
 	}
 
 	&__heading {
@@ -612,7 +612,7 @@ html {
 	}
 
 	&__wrap {
-		@include section-wrap(1280px);
+		@include section-wrap(1280px, 4rem);
 		box-shadow: 0px 8px 32px 16px rgba(31, 86, 125, 0.08);
 		padding-top: 2.5rem;
 		padding-bottom: 2rem;
@@ -677,7 +677,7 @@ html {
 	padding-bottom: 5rem;
 
 	&__wrap {
-		@include section-wrap(1280px);
+		@include section-wrap(1280px, 4rem);
 	}
 
 	&__heading {
@@ -762,7 +762,7 @@ html {
 	padding-bottom: 4rem;
 
 	&__wrap {
-		@include section-wrap(1280px);
+		@include section-wrap(1280px, 4rem);
 	}
 
 	&__heading {
@@ -833,7 +833,7 @@ html {
 	width: 100%;
 
 	&__wrap {
-		@include section-wrap(840px);
+		@include section-wrap(840px, 4rem);
 	}
 
 	.to-home-anchor {
@@ -976,7 +976,7 @@ html {
 	width: 100%;
 
 	&__wrap {
-		@include section-wrap(1280px);
+		@include section-wrap(1280px, 4rem);
 	}
 
 	.to-home-anchor {


### PR DESCRIPTION
Fix #111 

- The issue with the header title overlapping the logo should be resolved
- There was also another layout issue about alignment, so I put it there: the cell image was not correctly centered between the left and right texts. The right text was taking up more space.